### PR TITLE
feat: add AUR update delay setting

### DIFF
--- a/data/completion/bash_completion.in
+++ b/data/completion/bash_completion.in
@@ -74,12 +74,13 @@ _pamac()
 
             checkupdates)
                 COMPREPLY=( $( compgen -W '
-                  --builddir 
+                  --builddir
                   -a --aur
                   --no-aur
                   -q --quiet
                   --devel
                   --no-devel
+                  --aur-update-delay
                   ' -- "$cur" ) )
                 return 0
                 ;;
@@ -196,6 +197,7 @@ _pamac()
                   --no-confirm
                   --no-devel
                   --overwrite
+                  --aur-update-delay
                   ' -- "$cur" ) )
                 return 0
                 ;;

--- a/data/completion/fish_completion.in
+++ b/data/completion/fish_completion.in
@@ -39,6 +39,12 @@ __fish_pamac_subcommand upgrade -d 'Upgrade packages'
 
 __fish_pamac_subcommand update -d 'Update your system'
 
+# Checkupdates options
+complete -c pamac -n "__fish_seen_subcommand_from checkupdates" -l aur-update-delay -x -d 'number of days to wait before showing AUR updates (0 to disable)'
+
+# Update/Upgrade options
+complete -c pamac -n "__fish_seen_subcommand_from upgrade update" -l aur-update-delay -x -d 'number of days to wait before showing AUR updates (0 to disable)'
+
 __fish_pamac_subcommand list -r -d 'List packages, groups, repositories or files'
 
 __fish_pamac_subcommand clone -r -d 'Clone or sync packages build files from AUR'

--- a/data/completion/zsh_completion.in
+++ b/data/completion/zsh_completion.in
@@ -59,6 +59,7 @@ _pamac_opts_checkupdates=(
   {-q,--quiet}'[only print one line per update]'
   "--devel[also check development packages updates (use with --aur)]"
   "--no-devel[do not check development packages updates]"
+  "--aur-update-delay[number of days to wait before showing AUR updates (0 to disable)]:days:"
 )
 
 _pamac_checkupdates() {
@@ -214,6 +215,7 @@ _pamac_opts_updategrade=(
   "--devel[also upgrade development packages (use with --aur)]"
   "--no-devel[do not upgrade development packages]"
   "--builddir[build directory (use with --aur), if no directory is given the one specified in pamac.conf file is used]:dir:_files"
+  "--aur-update-delay[number of days to wait before showing AUR updates (0 to disable)]:days:"
 )
 
 _pamac_updategrade() {

--- a/data/doc/pamac.8.asciidoc
+++ b/data/doc/pamac.8.asciidoc
@@ -159,6 +159,7 @@ given the one specified in `pamac.conf` is used
 *--quiet, -q* ::: only print one line per update
 *--devel* ::: also check development packages updates (use with *--aur*)
 *--no-devel* ::: do not check development packages updates
+*--aur-update-delay* <days> ::: number of days to wait before showing AUR updates (0 to disable)
 
 Exit code is 100 if updates are available.
 
@@ -185,6 +186,7 @@ specified by separating them with comma
 *--no-devel* ::: do not upgrade development packages
 *--builddir* <dir> ::: build directory (use with *--aur*), if no directory is
 given the one specified in `pamac.conf` file is used
+*--aur-update-delay* <days> ::: number of days to wait before showing AUR updates (0 to disable)
 
 [[_clone]]
 === CLONE ===

--- a/data/doc/pamac.conf.5.asciidoc
+++ b/data/doc/pamac.conf.5.asciidoc
@@ -51,6 +51,10 @@ Options
 *CheckAURVCSUpdates*::
 	When check updates from AUR support is enabled check for vcs updates.
 
+*AURUpdateDelayDays =* number::
+	Number of days to wait before showing AUR updates.
+	If set to 0 the delay is disabled.
+
 *BuildDirectory =* /path/to/builddir::
 	The location of the directory where AUR build files are cloned and packages built.
 	This configuration is overriden by the AURDEST environment variable.

--- a/src/cli.vala
+++ b/src/cli.vala
@@ -708,8 +708,9 @@ namespace Pamac {
 				bool refresh_tmp_files_dbs = false;
 				bool download_updates = false;
 				string? builddir = null;
+				int64 aur_update_delay = -1;
 				try {
-					var options = new OptionEntry[10];
+					var options = new OptionEntry[11];
 					options[0] = { "help", 'h', 0, OptionArg.NONE, ref help, null, null };
 					options[1] = { "quiet", 'q', 0, OptionArg.NONE, ref quiet, null, null };
 					options[2] = { "aur", 'a', 0, OptionArg.NONE, ref aur, null, null };
@@ -719,6 +720,7 @@ namespace Pamac {
 					options[6] = { "builddir", 0, 0, OptionArg.STRING, ref builddir, null, null };
 					options[7] = { "refresh-tmp-files-dbs", 0, 0, OptionArg.NONE, ref refresh_tmp_files_dbs, null, null };
 					options[8] = { "download-updates", 0, 0, OptionArg.NONE, ref download_updates, null, null };
+					options[9] = { "aur-update-delay", 0, 0, OptionArg.INT64, ref aur_update_delay, null, null };
 					var opt_context = new OptionContext (null);
 					opt_context.set_help_enabled (false);
 					opt_context.add_main_entries (options, null);
@@ -761,6 +763,9 @@ namespace Pamac {
 				if (no_devel) {
 					database.config.check_aur_vcs_updates = false;
 				}
+				if (aur_update_delay >= 0) {
+					database.config.aur_update_delay_days = (uint64) aur_update_delay;
+				}
 				if (database.config.check_aur_vcs_updates) {
 					if (Posix.geteuid () == 0) {
 						// checking as root
@@ -790,8 +795,9 @@ namespace Pamac {
 				string? ignore = null;
 				bool dry_run = false;
 				bool no_refresh = false;
+				int64 aur_update_delay = -1;
 				try {
-					var options = new OptionEntry[15];
+					var options = new OptionEntry[16];
 					options[0] = { "help", 'h', 0, OptionArg.NONE, ref help, null, null };
 					options[1] = { "aur", 'a', 0, OptionArg.NONE, ref aur, null, null };
 					options[2] = { "no-aur", 0, 0, OptionArg.NONE, ref no_aur, null, null };
@@ -807,6 +813,7 @@ namespace Pamac {
 					options[12] = { "download-only", 'w', 0, OptionArg.NONE, ref download_only, null, null };
 					options[13] = { "dry-run", 'd', 0, OptionArg.NONE, ref dry_run, null, null };
 					options[14] = { "no-refresh", 0, 0, OptionArg.NONE, ref no_refresh, null, null };
+					options[15] = { "aur-update-delay", 0, 0, OptionArg.INT64, ref aur_update_delay, null, null };
 					var opt_context = new OptionContext (null);
 					opt_context.set_help_enabled (false);
 					opt_context.add_main_entries (options, null);
@@ -870,6 +877,9 @@ namespace Pamac {
 				}
 				if (disable_downgrade) {
 					database.config.enable_downgrade = false;
+				}
+				if (aur_update_delay >= 0) {
+					database.config.aur_update_delay_days = (uint64) aur_update_delay;
 				}
 				init_transaction ();
 				if (dry_run) {
@@ -1459,7 +1469,8 @@ namespace Pamac {
 								"  --no-aur",
 								"  --quiet, -q",
 								"  --devel",
-								"  --no-devel"};
+								"  --no-devel",
+								"  --aur-update-delay <%s>".printf (dgettext (null, "days"))};
 			foreach (unowned string option in options) {
 				int length = option.char_count ();
 				if (length > max_length) {
@@ -1471,7 +1482,8 @@ namespace Pamac {
 								dgettext (null, "do not check updates in AUR"),
 								dgettext (null, "only print one line per update"),
 								dgettext (null, "also check development packages updates (use with --aur)"),
-								dgettext (null, "do not check development packages updates")};
+								dgettext (null, "do not check development packages updates"),
+								dgettext (null, "number of days to wait before showing AUR updates (0 to disable)")};
 			int i = 0;
 			foreach (unowned string option in options) {
 				print_property (option, details[i], max_length);
@@ -1499,7 +1511,8 @@ namespace Pamac {
 								"  --no-aur",
 								"  --devel",
 								"  --no-devel",
-								"  --builddir <%s>".printf (dgettext (null, "dir"))};
+								"  --builddir <%s>".printf (dgettext (null, "dir")),
+								"  --aur-update-delay <%s>".printf (dgettext (null, "days"))};
 			foreach (unowned string option in options) {
 				int length = option.char_count ();
 				if (length > max_length) {
@@ -1519,7 +1532,8 @@ namespace Pamac {
 								dgettext (null, "do not upgrade packages installed from AUR"),
 								dgettext (null, "also upgrade development packages (use with --aur)"),
 								dgettext (null, "do not upgrade development packages"),
-								dgettext (null, "build directory (use with --aur), if no directory is given the one specified in pamac.conf file is used")};
+								dgettext (null, "build directory (use with --aur), if no directory is given the one specified in pamac.conf file is used"),
+								dgettext (null, "number of days to wait before showing AUR updates (0 to disable)")};
 			int i = 0;
 			foreach (unowned string option in options) {
 				print_property (option, details[i], max_length);

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,7 +2,7 @@ gobject = dependency('gobject-2.0')
 gio = dependency('gio-2.0')
 gio_unix = dependency('gio-unix-2.0')
 
-libpamac = dependency('pamac', version : '>=11.7.1')
+libpamac = dependency('pamac', version : '>=11.7.4')
 
 common_vala_args = ['--pkg=posix', '--vapidir=' + join_paths(meson.global_source_root(), 'vapi')]
 common_c_args = ['-DGETTEXT_PACKAGE="pamac"']


### PR DESCRIPTION
This patch adds CLI support for the new AURUpdateDelayDays setting. The setting itself, the config parsing, and the filtering logic live in the companion libpamac pull request.

The CLI gains a --aur-update-delay <days> option for both pamac checkupdates and pamac upgrade/update. It lets the user override how many days must pass before a newly-updated AUR package is shown in the update scan. A value of 0 disables the delay entirely; when the option is omitted, the value from pamac.conf is used. Help text, man pages, and shell completions for bash/zsh/fish are updated accordingly. I think I caught all of the help text related changes required. 

Link to libpamac PR: https://github.com/manjaro/libpamac/pull/8